### PR TITLE
Routing logic & toast duration

### DIFF
--- a/packages/datum-web/apps/operator/src/app/(protected)/customers/users/page.tsx
+++ b/packages/datum-web/apps/operator/src/app/(protected)/customers/users/page.tsx
@@ -1,9 +1,9 @@
-import UsersPage from '@/components/pages/protected/workspace/customer/users/users-page'
-
 import type { Metadata } from 'next/types'
 
+import UsersPage from '@/components/pages/protected/workspace/customer/users/users-page'
+
 export const metadata: Metadata = {
-  title: 'Workspace Users',
+  title: 'Users',
 }
 
 const Page: React.FC = () => {

--- a/packages/datum-web/apps/operator/src/app/(protected)/dashboard/page.tsx
+++ b/packages/datum-web/apps/operator/src/app/(protected)/dashboard/page.tsx
@@ -1,6 +1,11 @@
+import { Metadata } from 'next'
 import React from 'react'
 
 import DashboardPage from '@/components/pages/protected/workspace/dashboard/dashboard'
+
+export const metadata: Metadata = {
+  title: 'Dashboard',
+}
 
 const DashboardLanding = () => {
   return <DashboardPage />

--- a/packages/datum-web/apps/operator/src/app/(protected)/profile/page.tsx
+++ b/packages/datum-web/apps/operator/src/app/(protected)/profile/page.tsx
@@ -1,9 +1,9 @@
-import ProfilePage from '@/components/pages/protected/profile/profile-page'
-
 import type { Metadata } from 'next/types'
 
+import ProfilePage from '@/components/pages/protected/profile/profile-page'
+
 export const metadata: Metadata = {
-  title: 'Profile settings',
+  title: 'My Profile',
 }
 
 const Page: React.FC = () => {

--- a/packages/datum-web/apps/operator/src/app/(protected)/workspace/page.tsx
+++ b/packages/datum-web/apps/operator/src/app/(protected)/workspace/page.tsx
@@ -1,6 +1,11 @@
+import { Metadata } from 'next'
 import React from 'react'
 
 import WorkspacePage from '@/components/pages/protected/workspace/workspace-page'
+
+export const metadata: Metadata = {
+  title: 'My Workspaces',
+}
 
 const WorkspaceLanding: React.FC = () => {
   return <WorkspacePage />

--- a/packages/datum-web/apps/operator/src/app/(protected)/workspace/personal/settings/loading.tsx
+++ b/packages/datum-web/apps/operator/src/app/(protected)/workspace/personal/settings/loading.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import { Loading } from '@/components/shared/loading/loading'
+
+const Loader: React.FC = () => {
+  return <Loading />
+}
+
+export default Loader

--- a/packages/datum-web/apps/operator/src/app/(protected)/workspace/personal/settings/page.tsx
+++ b/packages/datum-web/apps/operator/src/app/(protected)/workspace/personal/settings/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next/types'
+
+import WorkspaceSettingsPage from '@/components/pages/protected/workspace/settings/workspace-settings-page'
+
+export const metadata: Metadata = {
+  title: 'Personal Workspace Settings',
+}
+
+const Page: React.FC = () => {
+  return <WorkspaceSettingsPage isPersonal />
+}
+
+export default Page

--- a/packages/datum-web/apps/operator/src/components/pages/protected/profile/profile-page.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/profile/profile-page.tsx
@@ -7,13 +7,14 @@ import {
   useGetUserProfileQuery,
   useUpdateUserInfoMutation,
 } from '@repo/codegen/src/schema'
+import { TOAST_DURATION } from '@repo/constants'
+import { toast } from '@repo/ui/use-toast'
 
 import PageTitle from '@/components/page-title'
 import { AvatarUpload } from '@/components/shared/avatar-upload/avatar-upload'
 
-import { ProfileNameForm } from './profile-name-form'
 import { pageStyles } from './page.styles'
-import { toast } from '@repo/ui/use-toast'
+import { ProfileNameForm } from './profile-name-form'
 
 const ProfilePage = () => {
   const { wrapper } = pageStyles()
@@ -33,23 +34,27 @@ const ProfilePage = () => {
       input,
     })
 
-
     if (error) {
       console.error(error)
       toast({
         title: 'Error updating profile',
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     } else {
       toast({
         title: 'Profile updated',
         variant: 'success',
+        duration: TOAST_DURATION,
       })
       update({
         ...sessionData,
         user: {
           ...sessionData?.user,
-          name: input?.firstName || input?.lastName ? `${input?.firstName} ${input?.lastName}` : sessionData?.user.name,
+          name:
+            input?.firstName || input?.lastName
+              ? `${input?.firstName} ${input?.lastName}`
+              : sessionData?.user.name,
         },
       })
     }

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/user/user-invitation-table-dropdown.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/user/user-invitation-table-dropdown.tsx
@@ -1,21 +1,20 @@
 'use client'
 
+import { BellMinus, Ellipsis } from 'lucide-react'
 import React, { useState } from 'react'
 
+import { useDeleteOrganizationInviteMutation } from '@repo/codegen/src/schema'
+import { TOAST_DURATION } from '@repo/constants'
+import { Datum } from '@repo/types'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@repo/ui/dropdown-menu'
-
-import { BellMinus, Ellipsis } from 'lucide-react'
-
-import { useDeleteOrganizationInviteMutation } from '@repo/codegen/src/schema'
-import { Datum } from '@repo/types'
+import { toast } from '@repo/ui/use-toast'
 
 import { pageStyles } from './page.styles'
-import { toast } from '@repo/ui/use-toast'
 
 type UserInvitationTableDropdownProps = {
   invitationId: Datum.InvitationId
@@ -37,6 +36,7 @@ const UserInvitationTableDropdown = ({
       toast({
         title: 'There was a problem deleting this invite, please try again',
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
 
@@ -44,6 +44,7 @@ const UserInvitationTableDropdown = ({
       toast({
         title: 'Invite deleted successfully',
         variant: 'success',
+        duration: TOAST_DURATION,
       })
       refetch()
     }

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/users/users-controls.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/users/users-controls.tsx
@@ -15,7 +15,7 @@ import {
 
 import FilterDialog from '@/components/shared/filter-dialog/filter-dialog'
 import Search from '@/components/shared/table-search/table-search'
-import { USER_FILTERS } from '@/utils/filters'
+import { USER_FILTERS } from '@/utils/filters/schemas'
 
 import { pageStyles } from './page.styles'
 import UsersFormDialog from './users-form-dialog'

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/users/users-form-dialog.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/users/users-form-dialog.tsx
@@ -8,6 +8,7 @@ import {
   useCreateBulkInviteMutation,
 } from '@repo/codegen/src/schema'
 import { pluralize } from '@repo/common/text'
+import { TOAST_DURATION } from '@repo/constants'
 import { Button } from '@repo/ui/button'
 import {
   Dialog,
@@ -97,6 +98,7 @@ const UsersFormDialog: React.FC<UsersDialogFormProps> = ({
       toast({
         title: `${pluralize('Invite', data.emails.length)} sent successfully`,
         variant: 'success',
+        duration: TOAST_DURATION,
       })
       setEmails([])
     } catch (error) {
@@ -105,6 +107,7 @@ const UsersFormDialog: React.FC<UsersDialogFormProps> = ({
       toast({
         title: `${pluralize('Invite', data.emails.length)} could not be sent`,
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
   }

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/users/users-table.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/customer/users/users-table.tsx
@@ -1,28 +1,28 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { getPathWithParams } from '@repo/common/routes'
 import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import { Datum } from '@repo/types'
 import { Avatar, AvatarFallback, AvatarImage } from '@repo/ui/avatar'
 import { Checkbox } from '@repo/ui/checkbox'
 import {
   ColumnDef,
-  FilterFn,
-  SortingFn,
+  ColumnFiltersState,
   DataTable,
   DataTableColumnHeader,
-  sortingFns,
-  rankItem,
-  compareItems,
-  ColumnFiltersState,
   Row,
 } from '@repo/ui/data-table'
 import { Tag, TagVariants } from '@repo/ui/tag'
-import { Datum } from '@repo/types'
 
 import { formatDate } from '@/utils/date'
+import {
+  booleanFilter,
+  fuzzyFilter,
+  fuzzySort,
+} from '@/utils/filters/functions'
 
 import { tableStyles } from './page.styles'
 
@@ -37,45 +37,6 @@ type UsersTableProps = {
 
 const { header, checkboxContainer, link, userDetails, userDetailsText } =
   tableStyles()
-
-const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
-  if (!value || value === '') return true
-
-  const cellValue = row.getValue(columnId)
-
-  if (!cellValue) return false
-
-  const itemRank = rankItem(cellValue, value)
-
-  addMeta({
-    itemRank,
-  })
-
-  return itemRank.passed
-}
-
-const booleanFilter: FilterFn<any> = (row, columnId, value) => {
-  let cellValue = row.getValue(columnId)
-
-  if (typeof cellValue === 'string') {
-    cellValue = cellValue.trim()
-  }
-
-  return Boolean(cellValue) === value
-}
-
-const fuzzySort: SortingFn<any> = (rowA, rowB, columnId) => {
-  let dir = 0
-
-  if (rowA.columnFiltersMeta[columnId]) {
-    dir = compareItems(
-      rowA.columnFiltersMeta[columnId].itemRank!,
-      rowB.columnFiltersMeta[columnId].itemRank!
-    )
-  }
-
-  return dir === 0 ? sortingFns.alphanumeric(rowA, rowB, columnId) : dir
-}
 
 const filterFns = {
   fuzzy: fuzzyFilter,

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/dashboard/dashboard.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/dashboard/dashboard.tsx
@@ -47,8 +47,8 @@ const DashboardPage = () => {
   // const activeUsers = users.filter((user) => user.setting.status === 'ACTIVE')
   // const activeUsersMonthly =
   //   users.length > 0 ? getMonthlyUsers(activeUsers) : []
-  const newUsersMonthly = users.length > 0 ? getMonthlyUsers(users) : []
-  const newUsersWeekly = users.length > 0 ? getWeeklyUsers(users) : []
+  const newUsersMonthly = getMonthlyUsers(users)
+  const newUsersWeekly = getWeeklyUsers(users)
   const { card, cardContent, link, row } = pageStyles()
 
   if (error) {

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/developers/actions/token-actions.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/developers/actions/token-actions.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { MoreHorizontal, Trash2 } from 'lucide-react'
-import { useToast } from '@repo/ui/use-toast'
-import { pageStyles } from '../page.styles'
+import { type UseQueryExecute } from 'urql'
+
+import { useDeletePersonalAccessTokenMutation } from '@repo/codegen/src/schema'
+import { TOAST_DURATION } from '@repo/constants'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,8 +12,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@repo/ui/dropdown-menu'
-import { useDeletePersonalAccessTokenMutation } from '@repo/codegen/src/schema'
-import { type UseQueryExecute } from 'urql'
+import { useToast } from '@repo/ui/use-toast'
+
+import { pageStyles } from '../page.styles'
 
 type TokenActionProps = {
   tokenId: string
@@ -32,6 +35,7 @@ export const TokenAction = ({ tokenId, refetchTokens }: TokenActionProps) => {
       toast({
         title: 'There was a problem deleting this token, please try again',
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
 
@@ -39,6 +43,7 @@ export const TokenAction = ({ tokenId, refetchTokens }: TokenActionProps) => {
       toast({
         title: 'Token deleted successfully',
         variant: 'success',
+        duration: TOAST_DURATION,
       })
       refetchTokens({
         requestPolicy: 'network-only',

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/developers/personal-access-token-form.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/developers/personal-access-token-form.tsx
@@ -1,42 +1,47 @@
 'use client'
-import React, { useEffect, useState } from 'react'
-import { useForm, SubmitHandler, Controller } from 'react-hook-form'
+
 import { zodResolver } from '@hookform/resolvers/zod'
+import { CalendarIcon } from '@radix-ui/react-icons'
+import { useCopyToClipboard } from '@uidotdev/usehooks'
+import { format } from 'date-fns'
+import { Copy } from 'lucide-react'
+import { useSession } from 'next-auth/react'
+import React, { useEffect, useState } from 'react'
+import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 import { z, infer as zInfer } from 'zod'
-import { Panel, PanelHeader } from '@repo/ui/panel'
-import { useToast } from '@repo/ui/use-toast'
-import { Input } from '@repo/ui/input'
-import {
-  Form,
-  FormItem,
-  FormField,
-  FormControl,
-  FormMessage,
-  FormLabel,
-} from '@repo/ui/form'
-import { Button } from '@repo/ui/button'
-import { personalAccessTokenFormStyles } from './personal-access-token-form-styles'
+
 import {
   CreatePersonalAccessTokenInput,
   useCreatePersonalAccessTokenMutation,
 } from '@repo/codegen/src/schema'
-import { useGqlError } from '@/hooks/useGqlError'
-import { useSession } from 'next-auth/react'
-import { Info } from '@repo/ui/info'
+import { TOAST_DURATION } from '@repo/constants'
+import { Button } from '@repo/ui/button'
+import { Calendar } from '@repo/ui/calendar'
 import { Checkbox } from '@repo/ui/checkbox'
-import { format } from 'date-fns'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
 } from '@repo/ui/dialog'
-import { useCopyToClipboard } from '@uidotdev/usehooks'
-import { Copy } from 'lucide-react'
-import { CalendarIcon } from '@radix-ui/react-icons'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@repo/ui/form'
+import { Info } from '@repo/ui/info'
+import { Input } from '@repo/ui/input'
+import { Panel, PanelHeader } from '@repo/ui/panel'
 import { Popover, PopoverContent, PopoverTrigger } from '@repo/ui/popover'
-import { Calendar } from '@repo/ui/calendar'
+import { useToast } from '@repo/ui/use-toast'
+
+import { useGqlError } from '@/hooks/useGqlError'
+
+import { personalAccessTokenFormStyles } from './personal-access-token-form-styles'
 
 const formSchema = z
   .object({
@@ -114,6 +119,7 @@ const PersonalAccessTokenForm = () => {
       toast({
         title: `Token created successfully`,
         variant: 'success',
+        duration: TOAST_DURATION,
       })
     }
   }
@@ -125,6 +131,7 @@ const PersonalAccessTokenForm = () => {
       toast({
         title: 'Token copied to clipboard',
         variant: 'success',
+        duration: TOAST_DURATION,
       })
     }
   }, [copiedText])
@@ -134,6 +141,7 @@ const PersonalAccessTokenForm = () => {
       toast({
         title: errorMessages.join('\n'),
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
   }, [errorMessages])

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/contacts/contacts-controls.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/contacts/contacts-controls.tsx
@@ -1,8 +1,5 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
-import { useState } from 'react'
 import {
   Check,
   ChevronDown,
@@ -12,18 +9,22 @@ import {
   Trash,
   User,
 } from 'lucide-react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 
 import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import type { Datum } from '@repo/types'
 import { Button } from '@repo/ui/button'
+import type { ColumnFiltersState } from '@repo/ui/data-table'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@repo/ui/dropdown-menu'
-import type { ColumnFiltersState } from '@repo/ui/data-table'
-import type { Datum } from '@repo/types'
 
+import FilterDialog from '@/components/shared/filter-dialog/filter-dialog'
 import {
   Accordion,
   AccordionContent,
@@ -33,11 +34,10 @@ import {
 import Search from '@/components/shared/table-search/table-search'
 import { useLists } from '@/hooks/useLists'
 import { createListMembers, removeListMembers } from '@/query/lists'
+import { CONTACT_FILTERS } from '@/utils/filters/schemas'
 
 import ContactFormDialog from './contacts-form-dialog'
-import FilterDialog from '@/components/shared/filter-dialog/filter-dialog'
 import { pageStyles } from './page.styles'
-import { CONTACT_FILTERS } from '@/utils/filters'
 
 type ContactsControlsProps = {
   search(query: string): void

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/contacts/contacts-table.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/contacts/contacts-table.tsx
@@ -1,27 +1,27 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { getPathWithParams } from '@repo/common/routes'
 import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import { Datum } from '@repo/types'
 import { Checkbox } from '@repo/ui/checkbox'
 import {
   ColumnDef,
-  FilterFn,
-  SortingFn,
+  ColumnFiltersState,
   DataTable,
   DataTableColumnHeader,
-  sortingFns,
-  rankItem,
-  compareItems,
-  ColumnFiltersState,
   Row,
 } from '@repo/ui/data-table'
 import { Tag } from '@repo/ui/tag'
-import { Datum } from '@repo/types'
 
 import { formatDate } from '@/utils/date'
+import {
+  booleanFilter,
+  fuzzyFilter,
+  fuzzySort,
+} from '@/utils/filters/functions'
 import { sortAlphabetically } from '@/utils/sort'
 
 import ContactsTableDropdown from './contacts-table-dropdown'
@@ -37,45 +37,6 @@ type ContactsTableProps = {
 }
 
 const { header, checkboxContainer, link } = tableStyles()
-
-const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
-  if (!value || value === '') return true
-
-  const cellValue = row.getValue(columnId)
-
-  if (!cellValue) return false
-
-  const itemRank = rankItem(cellValue, value)
-
-  addMeta({
-    itemRank,
-  })
-
-  return itemRank.passed
-}
-
-const booleanFilter: FilterFn<any> = (row, columnId, value) => {
-  let cellValue = row.getValue(columnId)
-
-  if (typeof cellValue === 'string') {
-    cellValue = cellValue.trim()
-  }
-
-  return Boolean(cellValue) === value
-}
-
-const fuzzySort: SortingFn<any> = (rowA, rowB, columnId) => {
-  let dir = 0
-
-  if (rowA.columnFiltersMeta[columnId]) {
-    dir = compareItems(
-      rowA.columnFiltersMeta[columnId].itemRank!,
-      rowB.columnFiltersMeta[columnId].itemRank!,
-    )
-  }
-
-  return dir === 0 ? sortingFns.alphanumeric(rowA, rowB, columnId) : dir
-}
 
 const filterFns = {
   fuzzy: fuzzyFilter,

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/list/list-delete-dialog.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/list/list-delete-dialog.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { TriangleAlert } from 'lucide-react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 
 import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import { Datum } from '@repo/types'
 import { Button } from '@repo/ui/button'
 import {
   Dialog,
@@ -14,13 +15,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@repo/ui/dialog'
-import { Datum } from '@repo/types'
-
-import { Loading } from '@/components/shared/loading/loading'
-import { useAsyncFn } from '@/hooks/useAsyncFn'
-import { removeLists } from '@/query/lists'
-
-import { deleteDialogStyles } from './page.styles'
 import {
   Form,
   FormControl,
@@ -32,8 +26,13 @@ import {
   zodResolver,
 } from '@repo/ui/form'
 import { Input } from '@repo/ui/input'
+
+import { Loading } from '@/components/shared/loading/loading'
+import { useAsyncFn } from '@/hooks/useAsyncFn'
+import { removeLists } from '@/query/lists'
 import { DeletionInput, DeletionSchema } from '@/utils/schemas'
-import { useEffect } from 'react'
+
+import { deleteDialogStyles } from './page.styles'
 
 type ListDeleteFormProps = {
   lists: Datum.List[]

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/list/list-page.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/list/list-page.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { useSession } from 'next-auth/react'
-import React, { useState } from 'react'
 import {
   ArrowLeft,
   ChevronDown,
@@ -12,10 +10,13 @@ import {
   Trash,
   Users2,
 } from 'lucide-react'
+import { useSession } from 'next-auth/react'
 import Link from 'next/link'
+import React, { useState } from 'react'
 
 import { exportExcel } from '@repo/common/csv'
-import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import { OPERATOR_APP_ROUTES, TOAST_DURATION } from '@repo/constants'
+import type { Datum } from '@repo/types'
 import { Button } from '@repo/ui/button'
 import { Row } from '@repo/ui/data-table'
 import {
@@ -26,23 +27,21 @@ import {
 } from '@repo/ui/dropdown-menu'
 import { Tag } from '@repo/ui/tag'
 import { toast } from '@repo/ui/use-toast'
-import type { Datum } from '@repo/types'
 
-import { Loading } from '@/components/shared/loading/loading'
-import ListDeleteDialog from '@/components/pages/protected/workspace/marketing/list/list-delete-dialog'
 import ListsAddContactsDialog from '@/components/pages/protected/workspace/marketing/list/list-add-contacts-dialog'
+import ListDeleteDialog from '@/components/pages/protected/workspace/marketing/list/list-delete-dialog'
+import { Error } from '@/components/shared/error/error'
+import { Loading } from '@/components/shared/loading/loading'
 import { useContacts } from '@/hooks/useContacts'
 import { useList } from '@/hooks/useLists'
 import { editLists } from '@/query/lists'
 import { formatContactsExportData } from '@/utils/export'
 import { ListInput } from '@/utils/schemas'
 
-import { pageStyles as listsStyles } from '../lists/page.styles'
 import ListFormDialog from '../lists/lists-form-dialog'
-
+import { pageStyles as listsStyles } from '../lists/page.styles'
 import ListContactsTable from './list-contacts-table'
 import { pageStyles } from './page.styles'
-import { Error } from '@/components/shared/error/error'
 
 type ListPageProps = {
   id: Datum.ListId
@@ -113,6 +112,7 @@ const ListPage = ({ id }: ListPageProps) => {
 
     toast({
       title: 'Copied to clipboard',
+      duration: TOAST_DURATION,
     })
   }
 

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/lists/lists-table.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/marketing/lists/lists-table.tsx
@@ -1,25 +1,26 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { getPathWithParams } from '@repo/common/routes'
 import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import type { Datum } from '@repo/types'
 import { Checkbox } from '@repo/ui/checkbox'
 import {
   ColumnDef,
-  FilterFn,
-  SortingFn,
+  ColumnFiltersState,
   DataTable,
   DataTableColumnHeader,
-  sortingFns,
-  rankItem,
-  compareItems,
-  ColumnFiltersState,
   Row,
 } from '@repo/ui/data-table'
 import { Tag } from '@repo/ui/tag'
-import type { Datum } from '@repo/types'
+
+import {
+  booleanFilter,
+  fuzzyFilter,
+  fuzzySort,
+} from '@/utils/filters/functions'
 
 import ListsTableDropdown from './lists-table-dropdown'
 import { tableStyles } from './page.styles'
@@ -35,40 +36,9 @@ type ListsTableProps = {
 
 const { header, checkboxContainer, link } = tableStyles()
 
-const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
-  if (!value || value === '') return true
-
-  const cellValue = row.getValue(columnId)
-
-  if (!cellValue) return false
-
-  const itemRank = rankItem(cellValue, value)
-
-  addMeta({
-    itemRank,
-  })
-
-  return itemRank.passed
-}
-
-const emptyFilter: FilterFn<any> = (row, columnId, value) => Boolean(value)
-
-const fuzzySort: SortingFn<any> = (rowA, rowB, columnId) => {
-  let dir = 0
-
-  if (rowA.columnFiltersMeta[columnId]) {
-    dir = compareItems(
-      rowA.columnFiltersMeta[columnId]?.itemRank!,
-      rowB.columnFiltersMeta[columnId]?.itemRank!,
-    )
-  }
-
-  return dir === 0 ? sortingFns.alphanumeric(rowA, rowB, columnId) : dir
-}
-
 const filterFns = {
   fuzzy: fuzzyFilter,
-  empty: emptyFilter,
+  empty: booleanFilter,
 }
 
 export const LIST_COLUMNS: ColumnDef<Datum.List>[] = [

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/invite-form.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/invite-form.tsx
@@ -11,6 +11,7 @@ import {
   useCreateBulkInviteMutation,
 } from '@repo/codegen/src/schema'
 import { pluralize } from '@repo/common/text'
+import { TOAST_DURATION } from '@repo/constants'
 import { Button } from '@repo/ui/button'
 import {
   Form,
@@ -88,6 +89,7 @@ const InviteForm = ({ inviteAdmins, refetchInvites }: InviteFormProps) => {
       toast({
         title: 'Error inviting members',
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     } else {
       toast({
@@ -111,6 +113,7 @@ const InviteForm = ({ inviteAdmins, refetchInvites }: InviteFormProps) => {
       toast({
         title: errorMessages.join('\n'),
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
   }, [errorMessages])

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/members-form-dialog.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/members-form-dialog.tsx
@@ -6,6 +6,7 @@ import {
   OrgMembershipRole,
   useUpdateUserRoleInOrgMutation,
 } from '@repo/codegen/src/schema'
+import { TOAST_DURATION } from '@repo/constants'
 import { Datum } from '@repo/types'
 import { Button } from '@repo/ui/button'
 import {
@@ -93,11 +94,13 @@ const MembersFormDialog = ({
         toast({
           title: `Error ${result.error.message}`,
           variant: 'destructive',
+          duration: TOAST_DURATION,
         })
       } else {
         toast({
           title: 'Role updated successfully',
           variant: 'success',
+          duration: TOAST_DURATION,
         })
         handleCancel()
       }
@@ -105,6 +108,7 @@ const MembersFormDialog = ({
       toast({
         title: `Unexpected error: ${(err as Error).message}`,
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
   }

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/members-page.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/members-page.tsx
@@ -11,6 +11,7 @@ import {
   useRemoveUserFromOrgMutation,
 } from '@repo/codegen/src/schema'
 import { exportExcel } from '@repo/common/csv'
+import { TOAST_DURATION } from '@repo/constants'
 import type { Datum } from '@repo/types'
 import { Button } from '@repo/ui/button'
 import { Row } from '@repo/ui/data-table'
@@ -122,11 +123,13 @@ const MembersPage: React.FC = () => {
           toast({
             title: `Error ${result.error.message}`,
             variant: 'destructive',
+            duration: TOAST_DURATION,
           })
         } else {
           toast({
             title: 'Invite deleted successfully',
             variant: 'success',
+            duration: TOAST_DURATION,
           })
 
           refetchInvites({
@@ -138,6 +141,7 @@ const MembersPage: React.FC = () => {
       toast({
         title: `Unexpected error: ${(err as Error).message}`,
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
   }
@@ -153,12 +157,14 @@ const MembersPage: React.FC = () => {
           toast({
             title: `Error ${result.error.message}`,
             variant: 'destructive',
+            duration: TOAST_DURATION,
           })
         } else {
           setOpenDeleteDialog(false)
           toast({
             title: 'Team member removed successfully',
             variant: 'success',
+            duration: TOAST_DURATION,
           })
           refetchMembers({ requestPolicy: 'network-only' })
         }
@@ -168,6 +174,7 @@ const MembersPage: React.FC = () => {
       toast({
         title: `Unexpected error: ${(err as Error).message}`,
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     }
   }

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/members-table.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/members/members-table.tsx
@@ -13,13 +13,14 @@ import {
   ColumnFiltersState,
   DataTable,
   DataTableColumnHeader,
-  FilterFn,
   Row,
-  SortingFn,
-  compareItems,
-  rankItem,
-  sortingFns,
 } from '@repo/ui/data-table'
+
+import {
+  booleanFilter,
+  fuzzyFilter,
+  fuzzySort,
+} from '@/utils/filters/functions'
 
 import MembersTableDropdown from './members-table-dropdown'
 import { pageStyles } from './page.styles'
@@ -47,45 +48,6 @@ export const MembersTable = ({
 }: MembersTableProps) => {
   const { checkboxContainer, userDetails, userDetailsText, header } =
     pageStyles()
-
-  const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
-    if (!value || value === '') return true
-
-    const cellValue = row.getValue(columnId)
-
-    if (!cellValue) return false
-
-    const itemRank = rankItem(cellValue, value)
-
-    addMeta({
-      itemRank,
-    })
-
-    return itemRank.passed
-  }
-
-  const booleanFilter: FilterFn<any> = (row, columnId, value) => {
-    let cellValue = row.getValue(columnId)
-
-    if (typeof cellValue === 'string') {
-      cellValue = cellValue.trim()
-    }
-
-    return Boolean(cellValue) === value
-  }
-
-  const fuzzySort: SortingFn<any> = (rowA, rowB, columnId) => {
-    let dir = 0
-
-    if (rowA.columnFiltersMeta[columnId]) {
-      dir = compareItems(
-        rowA.columnFiltersMeta[columnId].itemRank!,
-        rowB.columnFiltersMeta[columnId].itemRank!,
-      )
-    }
-
-    return dir === 0 ? sortingFns.alphanumeric(rowA, rowB, columnId) : dir
-  }
 
   const filterFns = {
     fuzzy: fuzzyFilter,

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/settings/workspace-settings-page.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/settings/workspace-settings-page.tsx
@@ -9,13 +9,11 @@ import {
   useGetAllOrganizationsQuery,
   useUpdateOrganizationMutation,
 } from '@repo/codegen/src/schema'
-import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import { OPERATOR_APP_ROUTES, TOAST_DURATION } from '@repo/constants'
 import { toast } from '@repo/ui/use-toast'
 
 import PageTitle from '@/components/page-title'
 import { AvatarUpload } from '@/components/shared/avatar-upload/avatar-upload'
-import { Error } from '@/components/shared/error/error'
-import { Loading } from '@/components/shared/loading/loading'
 import { canDeleteRelation, useCheckPermissions } from '@/lib/authz/utils'
 
 import { pageStyles } from './page.styles'
@@ -23,7 +21,11 @@ import { WorkspaceDelete } from './workspace-delete'
 import { WorkspaceEmailForm } from './workspace-email-form'
 import { WorkspaceNameForm } from './workspace-name-form'
 
-const WorkspaceSettingsPage = () => {
+const WorkspaceSettingsPage = ({
+  isPersonal = false,
+}: {
+  isPersonal?: boolean
+}) => {
   const { push } = useRouter()
   const { wrapper } = pageStyles()
   const { data: sessionData, update } = useSession()
@@ -53,11 +55,13 @@ const WorkspaceSettingsPage = () => {
       toast({
         title: 'Error updating workspace',
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     } else {
       toast({
         title: 'Successfully updated workspace',
         variant: 'success',
+        duration: TOAST_DURATION,
       })
     }
   }
@@ -78,6 +82,7 @@ const WorkspaceSettingsPage = () => {
       toast({
         title: 'Error deleting workspace',
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     } else {
       if (response.extensions && sessionData) {
@@ -95,6 +100,7 @@ const WorkspaceSettingsPage = () => {
       toast({
         title: 'Successfully deleted workspace',
         variant: 'success',
+        duration: TOAST_DURATION,
       })
 
       push(OPERATOR_APP_ROUTES.workspace)
@@ -106,7 +112,10 @@ const WorkspaceSettingsPage = () => {
 
   return (
     <>
-      <PageTitle title="General Settings" className="mb-10" />
+      <PageTitle
+        title={isPersonal ? 'Personal Workspace Settings' : 'General Settings'}
+        className="mb-10"
+      />
       <div className={wrapper()}>
         <WorkspaceNameForm
           name={currentWorkspace?.name || ''}

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/workspace-existing.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/workspace-existing.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from 'next/navigation'
 
 import { OPERATOR_APP_ROUTES } from '@repo/constants'
-import { Panel, PanelHeader } from '@repo/ui/panel'
+import { Datum } from '@repo/types'
 import { Avatar, AvatarFallback, AvatarImage } from '@repo/ui/avatar'
 import { Button } from '@repo/ui/button'
+import { Panel, PanelHeader } from '@repo/ui/panel'
 import { Tag } from '@repo/ui/tag'
-import { Datum } from '@repo/types'
 
 import { existingWorkspacesStyles } from './page.styles'
 
@@ -58,9 +58,11 @@ export const ExistingWorkspaces = ({
                 <Button
                   variant="outline"
                   size="md"
-                  onClick={() => push(OPERATOR_APP_ROUTES.dashboard)}
+                  onClick={() =>
+                    push(OPERATOR_APP_ROUTES.personalWorkspaceSettings)
+                  }
                 >
-                  Go to Dashboard
+                  Edit Personal Workspace
                 </Button>
               )}
             </div>
@@ -81,9 +83,7 @@ export const ExistingWorkspaces = ({
               <div>
                 <Avatar variant="large">
                   {avatar && <AvatarImage src={avatar} />}
-                  <AvatarFallback>
-                    {name.substring(0, 2)}
-                  </AvatarFallback>
+                  <AvatarFallback>{name.substring(0, 2)}</AvatarFallback>
                 </Avatar>
               </div>
               <div className={orgInfo()}>

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/workspace-page.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/workspace-page.tsx
@@ -2,6 +2,7 @@
 
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 
 import {
   useCreateOrganizationMutation,
@@ -26,15 +27,17 @@ import { toast } from '@repo/ui/use-toast'
 
 import PageTitle from '@/components/page-title'
 import { createWorkspaceStyles } from '@/components/pages/protected/workspace/page.styles'
+import { Loading } from '@/components/shared/loading/loading'
 import { switchWorkspace } from '@/lib/user'
 import { WorkspaceNameInput, WorkspaceNameSchema } from '@/utils/schemas'
 
 import { ExistingWorkspaces } from './workspace-existing'
 
 const WorkspacePage = () => {
+  const [switching, setSwitching] = useState(false)
   const { push } = useRouter()
   const { data: sessionData, update: updateSession } = useSession()
-  const [{ data: allOrgs, fetching, stale }] = useGetAllOrganizationsQuery({
+  const [{ data: allOrgs }] = useGetAllOrganizationsQuery({
     pause: !sessionData,
   })
   const userId = sessionData?.user.userId
@@ -69,6 +72,7 @@ const WorkspacePage = () => {
 
   async function handleWorkspaceSwitch(orgId?: string) {
     if (orgId) {
+      setSwitching(true)
       const response = await switchWorkspace({
         target_organization_id: orgId,
       })
@@ -90,6 +94,8 @@ const WorkspacePage = () => {
       } else {
         push(OPERATOR_APP_ROUTES.dashboard)
       }
+
+      setSwitching(false)
     }
   }
 
@@ -115,6 +121,10 @@ const WorkspacePage = () => {
 
   async function onSubmit(data: WorkspaceNameInput) {
     await createWorkspace({ name: data.name })
+  }
+
+  if (switching) {
+    ;<Loading className="h-full w-full" />
   }
 
   return (

--- a/packages/datum-web/apps/operator/src/components/pages/protected/workspace/workspace-page.tsx
+++ b/packages/datum-web/apps/operator/src/components/pages/protected/workspace/workspace-page.tsx
@@ -7,7 +7,7 @@ import {
   useCreateOrganizationMutation,
   useGetAllOrganizationsQuery,
 } from '@repo/codegen/src/schema'
-import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import { OPERATOR_APP_ROUTES, TOAST_DURATION } from '@repo/constants'
 import { Button } from '@repo/ui/button'
 import {
   Form,
@@ -26,8 +26,6 @@ import { toast } from '@repo/ui/use-toast'
 
 import PageTitle from '@/components/page-title'
 import { createWorkspaceStyles } from '@/components/pages/protected/workspace/page.styles'
-import { Error } from '@/components/shared/error/error'
-import { Loading } from '@/components/shared/loading/loading'
 import { switchWorkspace } from '@/lib/user'
 import { WorkspaceNameInput, WorkspaceNameSchema } from '@/utils/schemas'
 
@@ -36,10 +34,9 @@ import { ExistingWorkspaces } from './workspace-existing'
 const WorkspacePage = () => {
   const { push } = useRouter()
   const { data: sessionData, update: updateSession } = useSession()
-  const [{ data: allOrgs, fetching, stale, error }] =
-    useGetAllOrganizationsQuery({
-      pause: !sessionData,
-    })
+  const [{ data: allOrgs, fetching, stale }] = useGetAllOrganizationsQuery({
+    pause: !sessionData,
+  })
   const userId = sessionData?.user.userId
   const [{ error: createError }, addOrganization] =
     useCreateOrganizationMutation()
@@ -88,7 +85,11 @@ const WorkspacePage = () => {
         })
       }
 
-      push(OPERATOR_APP_ROUTES.dashboard)
+      if (orgId === personalOrg?.node?.id) {
+        push(OPERATOR_APP_ROUTES.personalWorkspaceSettings)
+      } else {
+        push(OPERATOR_APP_ROUTES.dashboard)
+      }
     }
   }
 
@@ -101,11 +102,13 @@ const WorkspacePage = () => {
       toast({
         title: 'Error creating workspace',
         variant: 'destructive',
+        duration: TOAST_DURATION,
       })
     } else {
       toast({
         title: 'Workspace created',
         variant: 'success',
+        duration: TOAST_DURATION,
       })
     }
   }

--- a/packages/datum-web/apps/operator/src/components/shared/sidebar/sidebar-nav/sidebar-nav.tsx
+++ b/packages/datum-web/apps/operator/src/components/shared/sidebar/sidebar-nav/sidebar-nav.tsx
@@ -1,9 +1,11 @@
 'use client'
-import Link from 'next/link'
 
-import { NavHeading, type NavItem, type Separator } from '@/types'
+import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useSidebar } from '@/hooks/useSidebar'
+import { useEffect, useState } from 'react'
+
+import { cn } from '@repo/ui/lib/utils'
+import { Separator as Hr } from '@repo/ui/separator'
 
 import {
   Accordion,
@@ -11,9 +13,9 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/shared/sidebar/sidebar-accordion/sidebar-accordion'
-import { useEffect, useState } from 'react'
-import { cn } from '@repo/ui/lib/utils'
-import { Separator as Hr } from '@repo/ui/separator'
+import { useSidebar } from '@/hooks/useSidebar'
+import { NavHeading, type NavItem, type Separator } from '@/types'
+
 import { sidebarNavStyles } from './sidebar-nav.styles'
 
 interface SideNavProps {
@@ -25,8 +27,13 @@ interface SideNavProps {
 export function SideNav({ items, setOpen, className }: SideNavProps) {
   const path = usePathname()
   const { isOpen: isSidebarOpen, toggle: toggleOpen } = useSidebar()
-  const [openItems, setOpenItems] = useState<string[]>([])
-  const [lastOpenItems, setLastOpenItems] = useState<string[]>([])
+  const activeNavAccordions = items
+    .filter((item) => 'title' in item && 'href' in item)
+    .filter((item) => path.includes(item.href))
+    .map((item) => item.title)
+  const [openItems, setOpenItems] = useState<string[]>(activeNavAccordions)
+  const [lastOpenItems, setLastOpenItems] =
+    useState<string[]>(activeNavAccordions)
 
   const {
     nav,

--- a/packages/datum-web/apps/operator/src/components/shared/sidebar/sidebar.tsx
+++ b/packages/datum-web/apps/operator/src/components/shared/sidebar/sidebar.tsx
@@ -1,15 +1,17 @@
+import { ArrowLeft, MenuIcon } from 'lucide-react'
+import { useSession } from 'next-auth/react'
+import { usePathname } from 'next/navigation'
 import React, { useState } from 'react'
 
-import { useSidebar } from '@/hooks/useSidebar'
-import { ArrowLeft, MenuIcon } from 'lucide-react'
-import { cn } from '@repo/ui/lib/utils'
-import { sidebarStyles } from './sidebar.styles'
-import { SideNav } from './sidebar-nav/sidebar-nav'
-import { NavItems, PersonalNavItems } from '@/routes/dashboard'
-import { useSession } from 'next-auth/react'
 import { useGetAllOrganizationsQuery } from '@repo/codegen/src/schema'
-import { usePathname } from 'next/navigation'
 import { OPERATOR_APP_ROUTES } from '@repo/constants'
+import { cn } from '@repo/ui/lib/utils'
+
+import { useSidebar } from '@/hooks/useSidebar'
+import { NavItems, PersonalNavItems } from '@/routes/dashboard'
+
+import { SideNav } from './sidebar-nav/sidebar-nav'
+import { sidebarStyles } from './sidebar.styles'
 
 interface SidebarProps {
   className?: string
@@ -22,7 +24,10 @@ export default function Sidebar({ className }: SidebarProps) {
   const isProfile = pathname === OPERATOR_APP_ROUTES.profile
   const isSettings = pathname === OPERATOR_APP_ROUTES.settings
   const isWorkspace = pathname === OPERATOR_APP_ROUTES.workspace
-  const showWorkspaceNav = !isProfile && !isSettings && !isWorkspace
+  const isPersonalWorkspaceSettings =
+    pathname === OPERATOR_APP_ROUTES.personalWorkspaceSettings
+  const showWorkspaceNav =
+    !isProfile && !isSettings && !isWorkspace && !isPersonalWorkspaceSettings
 
   const { nav, sideNav, expandNav, expandNavIcon } = sidebarStyles({
     status,

--- a/packages/datum-web/apps/operator/src/routes/dashboard.tsx
+++ b/packages/datum-web/apps/operator/src/routes/dashboard.tsx
@@ -41,7 +41,7 @@ export const NavItems: (NavItem | Separator | NavHeading)[] = [
   },
   {
     title: 'Customers',
-    href: '/workspace/customers',
+    href: '/customers',
     icon: Users,
     isChildren: true,
     children: [
@@ -195,14 +195,14 @@ export const NavItems: (NavItem | Separator | NavHeading)[] = [
 
 export const PersonalNavItems: (NavItem | Separator | NavHeading)[] = [
   {
-    title: 'My workspaces',
-    href: '/workspace',
-    icon: LayersIcon,
-  },
-  {
-    title: 'Profile',
+    title: 'My Profile',
     href: '/profile',
     icon: UserPen,
+  },
+  {
+    title: 'My Workspaces',
+    href: '/workspace',
+    icon: LayersIcon,
   },
   // {
   //   title: 'General Settings',

--- a/packages/datum-web/apps/operator/src/utils/filters/functions.tsx
+++ b/packages/datum-web/apps/operator/src/utils/filters/functions.tsx
@@ -1,0 +1,46 @@
+import {
+  FilterFn,
+  SortingFn,
+  compareItems,
+  rankItem,
+  sortingFns,
+} from '@repo/ui/data-table'
+
+export const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
+  if (!value || value === '') return true
+
+  const cellValue = row.getValue(columnId)
+
+  if (!cellValue) return false
+
+  const itemRank = rankItem(cellValue, value)
+
+  addMeta({
+    itemRank,
+  })
+
+  return itemRank.passed
+}
+
+export const booleanFilter: FilterFn<any> = (row, columnId, value) => {
+  let cellValue = row.getValue(columnId)
+
+  if (typeof cellValue === 'string') {
+    cellValue = cellValue.trim()
+  }
+
+  return Boolean(cellValue) === value
+}
+
+export const fuzzySort: SortingFn<any> = (rowA, rowB, columnId) => {
+  let dir = 0
+
+  if (rowA.columnFiltersMeta[columnId]) {
+    dir = compareItems(
+      rowA.columnFiltersMeta[columnId].itemRank!,
+      rowB.columnFiltersMeta[columnId].itemRank!,
+    )
+  }
+
+  return dir === 0 ? sortingFns.alphanumeric(rowA, rowB, columnId) : dir
+}

--- a/packages/datum-web/apps/operator/src/utils/filters/schemas.tsx
+++ b/packages/datum-web/apps/operator/src/utils/filters/schemas.tsx
@@ -1,9 +1,9 @@
 import {
   Building,
   ChartLine,
-  Clock11,
   Clock4,
   Clock8,
+  Clock11,
   Coins,
   Cpu,
   Factory,
@@ -21,8 +21,8 @@ import {
   User,
   UserCheck,
   UserRoundCog,
-  Users,
   UserSquare2,
+  Users,
   WalletCards,
 } from 'lucide-react'
 

--- a/packages/datum-web/packages/constants/src/index.ts
+++ b/packages/datum-web/packages/constants/src/index.ts
@@ -30,6 +30,7 @@ export const OPERATOR_APP_ROUTES = {
   settings: '/settings',
   workspace: '/workspace',
   workspaceSettings: '/workspace/settings',
+  personalWorkspaceSettings: '/workspace/personal/settings',
   workspaceMembers: '/workspace/members',
   login: '/login',
   forgotPassword: '/forgot-password',
@@ -106,3 +107,4 @@ export const DEFAULT_AVATAR_DIMENSIONS: Datum.ImageDimensions = {
 export const PRIMARY_COLOR = '#F27A67'
 export const SECONDARY_COLOR = '#9C94B0'
 export const SPINNER_BG = '#FBC8BF'
+export const TOAST_DURATION = 5000


### PR DESCRIPTION
This PR adds a couple of tweaks to help with the flow and feel of the app, namely:

- Reduces the duration of Toasts (they should now close after 5 seconds)
- Changes routing logic so that when a user is logged into their personal org they cannot manage team members, see contacts and users etc.